### PR TITLE
use pipenv in pyeth Dockerfile

### DIFF
--- a/clients/pyethereum:develop/Dockerfile
+++ b/clients/pyethereum:develop/Dockerfile
@@ -6,21 +6,29 @@ RUN \
                  g++ autoconf automake pkgconfig libtool libffi-dev gmp-dev && \
   curl -sSf https://bootstrap.pypa.io/get-pip.py -o get-pip.py              && \
   python get-pip.py                                                         && \
-  git clone --depth 1 https://github.com/ethereum/pyethapp                  && \
-  cd pyethapp                                                               && \
-  python setup.py develop                                                   && \
-  echo "{}"                                                                    \
-      | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}"           \
-      | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"            \
-      | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"                         \
-      > /version.json                                                       && \
+  ln -s /usr/bin/pip /bin/pip && \
+  pip install pipenv && \
+  mkdir pyeth && \
+  cd pyeth && \
+  pipenv --two && \
+  pipenv install git+https://github.com/ethereum/serpent.git@develop#egg=ethereum-serpent && \
+  pipenv install git+https://github.com/ethereum/pyethereum.git@2f8efd70771703142ea763d6d41d93a0fe2afc21#egg=ethereum && \
+  pipenv install git+https://github.com/gsalgado/pyethapp.git@hive#egg=pyethapp && \
+  #echo "{}"                                                                    \
+  #    | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}"           \
+  #    | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"            \
+  #    | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"                         \
+  #    > /version.json                                                       && \
+  echo "{}" \
+      | jq ". + {\"repo\":\"pipenv test\"}" \
+      > /version.json && \
   apk del git make gcc g++ musl-dev curl pkgconfig libtool automake autoconf
 
 # We can't delete /pyethapp--it's necessary for pyethapp to function.
 
 # Inject the startup script
-ADD pyethapp.sh /pyethapp.sh
-RUN chmod +x /pyethapp.sh
+ADD pyethapp.sh /pyeth/pyethapp.sh
+RUN chmod +x /pyeth/pyethapp.sh
 
 # Add the config file
 
@@ -28,10 +36,11 @@ ADD config.yaml /root/.config/pyethapp/config.yaml
 
 # Add the block import script
 
-ADD importblock.py /importblock.py
-RUN chmod +x /importblock.py
+ADD importblock.py /pyeth/importblock.py
+RUN chmod +x /pyeth/importblock.py
 
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8546 30303
 
-CMD ["/pyethapp.sh"]
+WORKDIR "/pyeth"
+CMD ["/pyeth/pyethapp.sh"]

--- a/clients/pyethereum:develop/pyethapp.sh
+++ b/clients/pyethereum:develop/pyethapp.sh
@@ -33,14 +33,15 @@ fi
 
 if [ -f /chain.rlp ]; then
   echo "Found chain.rlp"
-  pyethapp -c eth.genesis="$genesis" $extra_config import /chain.rlp
+  pipenv pyethapp -c eth.genesis="$genesis" $extra_config import /chain.rlp
 fi
 
 if [ -d /blocks/ ]; then
   # VAST HACK! Turns out that trying to get a functioning pyethapp environment in order to import blocks
   # without actually running pyethapp is its own special form of torment. So...
   echo "from importblock import Importer; Importer(eth).run()" | \
-    pyethapp -c eth.genesis="$genesis" $extra_config run --console
+    # doesn't work with pipenv
+    pipenv pyethapp -c eth.genesis="$genesis" $extra_config run --console
 fi
 
 set -e
@@ -51,4 +52,4 @@ fi
 
 # --dev stops on error.
 
-pyethapp -c eth.genesis="$genesis" $extra_config run --dev
+pipenv pyethapp -c eth.genesis="$genesis" $extra_config run --dev


### PR DESCRIPTION
example of using pipenv in pyeth docker file. Note that the test `genesis-chain-blocks` fails, for some reason.

```
{
  "clients": {
    "pyethereum:develop": {
      "repo": "pipenv test"
    }
  },
  "validations": {
    "pyethereum:develop": {
      "smoke/genesis-chain": {
        "start": "2017-05-12T22:56:29.33555086Z",
        "end": "2017-05-12T22:56:36.452233911Z",
        "success": true
      },
      "smoke/genesis-chain-blocks": {
        "start": "2017-05-12T22:56:36.452430613Z",
        "end": "2017-05-12T22:56:46.673967923Z",
        "success": false
      },
      "smoke/genesis-keys": {
        "start": "2017-05-12T22:56:46.674222096Z",
        "end": "2017-05-12T22:56:50.737191295Z",
        "success": true
      },
      "smoke/genesis-only": {
        "start": "2017-05-12T22:56:50.737909536Z",
        "end": "2017-05-12T22:56:54.889491166Z",
        "success": true
      }
    }
  },
  "simulations": {
    "pyethereum:develop": {
      "smoke/lifecycle": {
        "start": "2017-05-12T22:56:55.089445239Z",
        "end": "2017-05-12T22:56:59.095383113Z",
        "success": true
      }
    }
  },
  "benchmarks": {
    "pyethereum:develop": {
      "smoke/genesis-retrieval": {
        "start": "2017-05-12T22:57:15.81981294Z",
        "end": "2017-05-12T22:57:21.003547438Z",
        "success": true,
        "iterations": 200,
        "ns/op": 6602971
      }
    }
  }
}
```